### PR TITLE
Fixed KeyError in Training

### DIFF
--- a/gpybo/gp.py
+++ b/gpybo/gp.py
@@ -72,7 +72,7 @@ class GP(nn.Module):
     def train(self, n_restarts: int = 10) -> None:
 
         best_loss = None
-        best_params = {}
+        best_params = copy.deepcopy({k: v for k, v in self.named_parameters()})
 
         for i in range(n_restarts):
 


### PR DESCRIPTION
On occasion, when the loss did not decrease, there would be a keyerror - this has just been fixed by initialising the dicitonary with the current values.

Resolves: #41