### PR TITLE
Override __getitem__ for MOMean / MOKernel

### DIFF
--- a/gpybo/kernel.py
+++ b/gpybo/kernel.py
@@ -345,9 +345,17 @@ class MOKernel(Kernel):
     def __init__(self, kernels: List[Kernel]) -> None:
 
         super().__init__()
+
+        for k in kernels:
+            if not isinstance(k, Kernel):
+                raise TypeError(f'{k} must be a Kernel.')
+
         self.kernels = kernels
         for idx, k in enumerate(self.kernels):
             self.add_module(str(idx), k)
+
+    def __getitem__(self, item):
+        return self.kernels[item]
 
     @property
     def n_kernels(self) -> int:

--- a/gpybo/mean.py
+++ b/gpybo/mean.py
@@ -39,9 +39,17 @@ class MOMean(Mean):
     def __init__(self, means: List[Mean]) -> None:
 
         super().__init__()
+
+        for m in means:
+            if not isinstance(m, Mean):
+                raise TypeError(f'{m} must be a Mean.')
+
         self.means = means
         for idx, m in enumerate(self.means):
             self.add_module(str(idx), m)
+
+    def __getitem__(self, item):
+        return self.means[item]
 
     @property
     def n_means(self):


### PR DESCRIPTION
Provided the ability to index the relevant mean / kernel from a `MOMean` / `MOKernel`

Resolves: #78