### PR TITLE
Generalised MOGP to GP

### DIFF
--- a/gpybo/kernel.py
+++ b/gpybo/kernel.py
@@ -40,6 +40,9 @@ class Kernel(nn.Module):
     def __rmul__(self, other: Any) -> 'ProductKernel':
         return ProductKernel(other, self)
 
+    def __len__(self):
+        return 1
+
     def __call__(self, x: Tensor, xp: Tensor) -> Tensor:
         return self.calculate(x, xp)
 

--- a/gpybo/likelihood.py
+++ b/gpybo/likelihood.py
@@ -42,8 +42,6 @@ class GaussianLikelihood(Likelihood):
             Log Likelihood of outputs given the data.
         """
 
-        y = y.view(-1, 1)
-
         kern = kernel.calculate(x, x)
         K = kern + noise * torch.eye(kern.shape[0])
 

--- a/gpybo/mean.py
+++ b/gpybo/mean.py
@@ -19,6 +19,9 @@ class Mean(nn.Module):
         msg = super().__repr__().replace('()', '(' + ', '.join(msg_list) + ')')
         return msg
 
+    def __len__(self) -> int:
+        return 1
+
     def calculate(self, xp: Tensor) -> Tensor:
         raise NotImplementedError('Mean::calculate()')
 

--- a/gpybo/utils/shaping.py
+++ b/gpybo/utils/shaping.py
@@ -45,3 +45,7 @@ def convert_tensor(x: Any) -> Any:
         return torch.tensor(x, dtype=torch.float32)
     else:
         return x
+
+
+def unwrap(x: Tensor):
+    return torch.stack(x.unbind(1)).view(-1, 1)


### PR DESCRIPTION
Updated the GP class definition to be a generalisation of MOGP to allow the user to easily GP/MOGP through the same interface - the only difference is the use of `MOMean`/`MOKernel` when requiring multiple outputs.

Resolves: #82
Resolves: #77