### PR TITLE
Provided qAcquisition Functions

### DIFF
--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -14,7 +14,7 @@ class TestExpectedImprovement:
         y = torch.sin(x)
 
         gp = GP(SquaredExponentialKernel()) | (x, y)
-        ei = ExpectedImprovement(gp)
+        ei = ExpectedImprovement(gp, alpha=0.0)
 
         xp = torch.tensor(2, dtype=torch.float32)
         ret_val = ei(xp)


### PR DESCRIPTION
Provided acquisition functions which rely on samples from the posterior and the reparameterisation trick as opposed to higher dimensional integrals as seen when calculating the cdf in the analytic cases.

Resolves: #89