### PR TITLE
Multiple samples prior to acquistion optimisation

### DIFF
--- a/gpybo/acquisition.py
+++ b/gpybo/acquisition.py
@@ -83,7 +83,7 @@ class qExpectedImprovement(BaseAcquisitionFunction):
     def forward(self, x: Tensor) -> Tensor:
 
         mv_norm = self.model.posterior(x)
-        samples = mv_norm.rsample((1, 512))
+        samples = mv_norm.rsample((1, 512)).requires_grad_(True)
 
         best_f = self.model.y.max()
         qei = (samples - best_f - self.alpha).clamp_min(0)

--- a/gpybo/gp.py
+++ b/gpybo/gp.py
@@ -212,7 +212,7 @@ class GP(nn.Module):
                 mv_norm = MultivariateNormal(mu, cov)
                 pd = True
             except:
-                cov += 1e-6 * torch.eye(cov.shape[0])
+                cov += 1e-4 * torch.eye(cov.shape[0])
 
         return mv_norm
 


### PR DESCRIPTION
Provided the ability to draw multiple samples before optimising the acquisition function - this should reduce the likelihood of hitting a local optimum.

Resolves: #96
Resolves: #97